### PR TITLE
guard against null reference exception when options is null

### DIFF
--- a/Discord.Interactions/Entities/Interaction/DiscordInteractionData.cs
+++ b/Discord.Interactions/Entities/Interaction/DiscordInteractionData.cs
@@ -38,7 +38,7 @@ namespace TehGM.Discord.Interactions
         // OPTIONS RETRIEVAL
         private bool TryGetOption<T>(string key, out T value, Func<object, T> parser)
         {
-            DiscordInteractionDataOption option = this.Options.FirstOrDefault(o => o.Name.Equals(key, StringComparison.OrdinalIgnoreCase));
+            DiscordInteractionDataOption option = this.Options?.FirstOrDefault(o => o.Name.Equals(key, StringComparison.OrdinalIgnoreCase));
             if (option == null || option.Value == null)
             {
                 value = default;


### PR DESCRIPTION
JSON serialization is set earlier in the file to omit the options field, and in cases where only optional parameters are specified in the command, this will throw a `NullReferenceException` where one isn't intended